### PR TITLE
Use text group name for concat to allow 1.2.x versions to work

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,7 +23,7 @@ class fail2ban::config {
 
   concat { '/etc/fail2ban/jail.local':
     owner => 'root',
-    group => 0,
+    group => 'root',
     mode  => '0644',
   }
   # Define one fragment with a header for the file, otherwise the concat exec


### PR DESCRIPTION
(rather than requiring the broken concat 2.0.x).

Very small change but required to allow this to work on many setups.