### PR TITLE
Service ssmtp is not valid on CentOS 7

### DIFF
--- a/manifests/jail/courierauth.pp
+++ b/manifests/jail/courierauth.pp
@@ -13,7 +13,7 @@ class fail2ban::jail::courierauth (
   # Use default courierauth filter from debian
   fail2ban::jail { 'courierauth':
     enabled  => true,
-    port     => 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s',
+    port     => 'smtp,smtps,imap2,imap3,imaps,pop3,pop3s',
     filter   => 'courierlogin',
     logpath  => $logpath,
     findtime => $findtime,

--- a/manifests/jail/couriersmtp.pp
+++ b/manifests/jail/couriersmtp.pp
@@ -13,7 +13,7 @@ class fail2ban::jail::couriersmtp (
   # Use default couriersmtp filter from debian
   fail2ban::jail { 'couriersmtp':
     enabled  => true,
-    port     => 'smtp,ssmtp',
+    port     => 'smtp,smtps',
     filter   => 'couriersmtp',
     logpath  => $logpath,
     findtime => $findtime,

--- a/manifests/jail/dovecot.pp
+++ b/manifests/jail/dovecot.pp
@@ -13,7 +13,7 @@ class fail2ban::jail::dovecot (
   # Use default dovecot filter
   fail2ban::jail { 'dovecot':
     enabled  => true,
-    port     => 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s',
+    port     => 'smtp,smtps,imap2,imap3,imaps,pop3,pop3s',
     filter   => 'dovecot',
     logpath  => $logpath,
     findtime => $findtime,

--- a/manifests/jail/postfix.pp
+++ b/manifests/jail/postfix.pp
@@ -13,7 +13,7 @@ class fail2ban::jail::postfix (
   # Use default postfix filter
   fail2ban::jail { 'postfix':
     enabled  => true,
-    port     => 'smtp,ssmtp',
+    port     => 'smtp,smtps',
     filter   => 'postfix',
     logpath  => $logpath,
     findtime => $findtime,

--- a/manifests/jail/sasl.pp
+++ b/manifests/jail/sasl.pp
@@ -16,7 +16,7 @@ class fail2ban::jail::sasl (
   # Use default sasl filter from debian
   fail2ban::jail { 'sasl':
     enabled  => true,
-    port     => 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s',
+    port     => 'smtp,smtps,imap2,imap3,imaps,pop3,pop3s',
     filter   => 'sasl',
     # You might consider monitoring /var/log/mail.warn instead if you are
     # running postfix since it would provide the same log lines at the

--- a/manifests/jail/sendmailauth.pp
+++ b/manifests/jail/sendmailauth.pp
@@ -13,7 +13,7 @@ class fail2ban::jail::sendmailauth (
   # Use default sendmailauth filter from rhel
   fail2ban::jail { 'sendmailauth':
     enabled  => true,
-    port     => 'smtp,ssmtp,imap2,imap3,imaps,pop3,pop3s',
+    port     => 'smtp,smtps,imap2,imap3,imaps,pop3,pop3s',
     filter   => 'sendmail-auth',
     logpath  => $logpath,
     findtime => $findtime,


### PR DESCRIPTION
The alias name ssmtp is not present in /etc/services on CentOS 7
resulting in all jails referencing ssmtp to fail on CentOS 7.
This patch changes the service name from ssmtp to smtps