### PR TITLE
Add `includes` parameter to filter definition

### DIFF
--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -6,9 +6,14 @@ define fail2ban::filter (
   $failregexes,
   $ensure    = present,
   $ignoreregexes = [],
+  $includes = [],
   $additional_defs = []
 ) {
   include fail2ban::config
+
+  if !is_array($includes) {
+    fail('includes must be an array')
+  }
 
   file { "/etc/fail2ban/filter.d/${name}.conf":
     ensure  => $ensure,

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -7,12 +7,17 @@ define fail2ban::filter (
   $ensure    = present,
   $ignoreregexes = [],
   $includes = [],
+  $includes_after = [],
   $additional_defs = []
 ) {
   include fail2ban::config
 
   if !is_array($includes) {
     fail('includes must be an array')
+  }
+
+  if !is_array($includes_after) {
+    fail("includes_after must be an array")
   }
 
   file { "/etc/fail2ban/filter.d/${name}.conf":

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -17,7 +17,7 @@ define fail2ban::filter (
   }
 
   if !is_array($includes_after) {
-    fail("includes_after must be an array")
+    fail('includes_after must be an array')
   }
 
   file { "/etc/fail2ban/filter.d/${name}.conf":

--- a/templates/filter.erb
+++ b/templates/filter.erb
@@ -1,6 +1,11 @@
 # Fail2Ban configuration file
 #
 
+<% if @includes -%>
+[INCLUDES]
+before = <%= @includes.join("\n         ") %>
+<% end -%>
+
 [Definition]
 
 <% @additional_defs.each do |line| -%>

--- a/templates/filter.erb
+++ b/templates/filter.erb
@@ -1,15 +1,20 @@
 # Fail2Ban configuration file
 #
 
-<% if @includes -%>
+<% if @includes or @includes_after -%>
 [INCLUDES]
+<%   if @includes -%>
 before = <%= @includes.join("\n         ") %>
+<%   end -%>
+<%   if @includes_after -%>
+after = <%= @includes_after.join("\n        ") %>
+<%   end -%>
 <% end -%>
 
 [Definition]
 
 <% @additional_defs.each do |line| -%>
-<%= line %>
+<%=  line %>
 <% end -%>
 
 # Option:  failregex


### PR DESCRIPTION
The default filters use an `include` mechanism to pull in common definitions:

    [INCLUDES]

    # Read common prefixes. If any customizations available -- read them from
    # common.local
    before = common.conf

From reading the fail2ban source code, multiple files can be included, if they're listed one per line:

    [INCLUDES]

    # multiple include files
    before = foo.conf
             bar.conf

This change adds an `includes` parameter to `fail2ban::filter` to allow something like the following:

    fail2ban::filter { 'sshd-root':
      ensure      => present ,
      includes    => [ 'common.conf' ] ,
      failregexes => [ '^%(__prefix_line)sFailed \S+ for root from <HOST>(?: port \d*)?(?: ssh\d*)?(: (ruser .*|(\S+ ID \S+ \(serial \d+\) CA )?\S+ %(__md5hex)s(, client user ".*", client host ".*")?))?\s*$' ] ,
    }

Where `__prefix_line` and `__md5hex` are defined in `common.conf`.