### PR TITLE
Addition of 'backend' variable for use in jail.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Here's the full list of parameters you can use:
  * `ignoreip` Override default IP(s) to ignore (e.g. don't ban this IP).
  * `order` Optional numerical position. This lets you order jails as you see
    fit.
+ * `backend` How should fail2ban look for modifications on log files.
 
 To remove a jail, simply remove the resource for it from your manifests:
 puppetlabs-concat will automatically remove all fragments that are not managed

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -13,7 +13,7 @@ define fail2ban::jail (
   $bantime   = false,
   $ignoreip  = false,
   $order     = false,
-  $jbackend  = false,
+  $backend  = false,
 ) {
   include fail2ban::config
 

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -13,6 +13,7 @@ define fail2ban::jail (
   $bantime   = false,
   $ignoreip  = false,
   $order     = false,
+  $jbackend  = false,
 ) {
   include fail2ban::config
 

--- a/templates/jail.erb
+++ b/templates/jail.erb
@@ -17,4 +17,6 @@ logpath = <%= @logpath %>
 <% end -%>
 <% if @ignoreip != false -%>ignoreip = <%= @ignoreip %>
 <% end -%>
+<% if @jbackend != false -%>backend = <%= @jbackend %>
+<% end -%>
 

--- a/templates/jail.erb
+++ b/templates/jail.erb
@@ -17,6 +17,6 @@ logpath = <%= @logpath %>
 <% end -%>
 <% if @ignoreip != false -%>ignoreip = <%= @ignoreip %>
 <% end -%>
-<% if @jbackend != false -%>backend = <%= @jbackend %>
+<% if @backend != false -%>backend = <%= @backend %>
 <% end -%>
 


### PR DESCRIPTION
This variable is very handy to have when your environment uses both systemd's journald and rsyslog for logging.