### PR TITLE
Add support for DragonFly BSD and FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This module supports
  * Debian 7 and 8
  * RHEL 6 and 7
  * CentOs 6 and 7
+ * DragonFly BSD 4.4
+ * FreeBSD 9 and 10
 
 Please note that a bug in puppet 3.x with regards to package dependencies will
 make it print warnings about missing dependencies. This issue was fixed in
@@ -149,6 +151,7 @@ with a concat::fragment resource (which the fail2ban::jail define uses).
  * sendmailreject
  * ssh_ddos
  * ssh
+ * ssh_pf
  * vsftpd
  * wuftpd
  * xinetd_fail

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,21 +4,33 @@
 # to it.
 class fail2ban::config {
 
-  $ignoreip = $fail2ban::ignoreip
-  $bantime = $fail2ban::bantime
-  $findtime = $fail2ban::findtime
-  $maxretry = $fail2ban::maxretry
-  $backend = $fail2ban::backend
+  $ignoreip  = $fail2ban::ignoreip
+  $bantime   = $fail2ban::bantime
+  $findtime  = $fail2ban::findtime
+  $maxretry  = $fail2ban::maxretry
+  $backend   = $fail2ban::backend
   $destemail = $fail2ban::destemail
   $banaction = $fail2ban::banaction
-  $mta = $fail2ban::mta
-  $protocol = $fail2ban::protocol
-  $action = $fail2ban::action
+  $mta       = $fail2ban::mta
+  $protocol  = $fail2ban::protocol
+  $action    = $fail2ban::action
+
+  $config_dir = $::osfamily ? {
+    /^(Debian|RedHat)$/     => '/etc/fail2ban',
+    /^(DragonFly|FreeBSD)$/ => '/usr/local/etc/fail2ban',
+  }
+
+  $pf_path = $::osfamily ? {
+    'DragonFly' => '/usr/sbin',
+    'FreeBSD'   => '/sbin',
+  }
 
   $jail_template_name = $::osfamily ? {
-    'Debian' => "${module_name}/debian_jail.conf.erb",
-    'RedHat' => "${module_name}/rhel_jail.conf.erb",
-    default  => fail("Unsupported Operating System family: ${::osfamily}"),
+    'Debian'    => "${module_name}/debian_jail.conf.erb",
+    'RedHat'    => "${module_name}/rhel_jail.conf.erb",
+    'DragonFly' => "${module_name}/freebsd_jail.conf.erb",
+    'FreeBSD'   => "${module_name}/freebsd_jail.conf.erb",
+    default     => fail("Unsupported Operating System family: ${::osfamily}"),
   }
 
   if $fail2ban::purge_jail_dot_d {
@@ -26,7 +38,7 @@ class fail2ban::config {
       debug('Not purging jail.d on wheezy since the package doesn\'t include capability to use it.')
     }
     else {
-      file { '/etc/fail2ban/jail.d':
+      file { "${config_dir}/jail.d":
         ensure  => directory,
         recurse => true,
         purge   => true,
@@ -34,31 +46,23 @@ class fail2ban::config {
     }
   }
 
-  file { '/etc/fail2ban/jail.conf':
+  file { "${config_dir}/jail.conf":
     ensure  => present,
-    owner   => 'root',
+    owner   => 0,
     group   => 0,
     mode    => '0644',
     content => template($jail_template_name),
   }
 
-  concat { '/etc/fail2ban/jail.local':
-    owner => 'root',
-    # The next line is not portable to some BSDs, but since the concat module
-    # doesn't let one use integer values for the $group parameter (doing so
-    # produces an error with future parser or 4.x) we're using a string value
-    # instead.
-    # See https://tickets.puppetlabs.com/browse/MODULES-2999 for report on the
-    # concat module. If this gets fixed and the concat module permits usage of
-    # integer values, we'll switch back to using a value of 0 for the $group
-    # parameter.
-    group => 'root',
+  concat { "${config_dir}/jail.local":
+    owner => 0,
+    group => 0,
     mode  => '0644',
   }
   # Define one fragment with a header for the file, otherwise the concat exec
   # errors out.
   concat::fragment { 'jail_header':
-    target => '/etc/fail2ban/jail.local',
+    target => "${config_dir}/jail.local",
     source => 'puppet:///modules/fail2ban/jail.header',
     order  => 01,
   }
@@ -71,9 +75,19 @@ class fail2ban::config {
         'puppet:///modules/site_fail2ban/conf.d/fail2ban',
         'puppet:///modules/fail2ban/conf.d/fail2ban'
       ],
-      owner => 'root',
+      owner => 0,
       group => 0,
       mode  => '0644';
+    }
+  }
+
+  if $::operatingsystem == 'freebsd' or $::operatingsystem == 'dragonfly' {
+    file { "${config_dir}/action.d/pf.conf":
+      ensure  => present,
+      owner   => 0,
+      group   => 0,
+      mode    => '0644',
+      content => template("${module_name}/pf.conf.erb")
     }
   }
 

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -21,7 +21,7 @@ define fail2ban::filter (
   file { "/etc/fail2ban/filter.d/${name}.conf":
     ensure  => $ensure,
     content => template('fail2ban/filter.erb'),
-    owner   => 'root',
+    owner   => 0,
     group   => 0,
     mode    => '0644',
     require => Class['fail2ban::config'],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,12 @@
 class fail2ban::install {
 
-  ensure_packages(['fail2ban'])
+  $fail2ban_package = $::osfamily ? {
+    /(Debian|RedHat)/     => 'fail2ban',
+    /(DragonFly|FreeBSD)/ => 'py27-fail2ban',
+    default               => 'fail2ban',
+  }
+
+  ensure_packages($fail2ban_package)
 
   if $::operatingsystem == 'gentoo' {
     Package['fail2ban'] {

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -21,12 +21,17 @@ define fail2ban::jail (
     warning('The $ensure parameter is now deprecated! to ensure that a fail2ban jail is absent, simply remove the resource.')
   }
 
+  $config_dir = $::osfamily ? {
+    /^(Debian|RedHat)$/     => '/etc/fail2ban',
+    /^(DragonFly|FreeBSD)$/ => '/usr/local/etc/fail2ban',
+  }
+
   # This has an implicit ordering that ensures proper functioning: the main
   # fragment is defined in the 'fail2ban::config' class and each fragment
   # implicitly requires the main concat target. Consequently, those fragments
   # are sure to be dealt with after package installation.
   concat::fragment { "jail_${name}":
-    target  => '/etc/fail2ban/jail.local',
+    target  => "${config_dir}/jail.local",
     content => template('fail2ban/jail.erb'),
   }
 

--- a/manifests/jail/ssh_pf.pp
+++ b/manifests/jail/ssh_pf.pp
@@ -1,0 +1,35 @@
+class fail2ban::jail::ssh_pf (
+  $maxretry = 'usedefault',
+  $findtime = false,
+  $ignoreip = false
+  $port     = ''
+  ) {
+
+  $real_maxretry = $maxretry ? {
+    'usedefault' => '3',
+    default      => $maxretry
+  }
+
+  $real_port = $port ? {
+    ''      => 'ssh',
+    default => 'ssh'
+  }
+
+  $logpath = $::osfamily ? {
+    /^(DragonFly|FreeBSD)$/ => '/var/log/auth.log',
+    default                 => fail("Unsupported Operating System family: ${::osfamily}"),
+  }
+
+  # Use default sshd filter
+  fail2ban::jail { 'ssh-pf':
+    enabled  => true,
+    action   => 'pf',
+    port     => $real_port,
+    filter   => 'sshd',
+    logpath  => $logpath,
+    maxretry => $real_maxretry,
+    findtime => $findtime,
+    ignoreip => $ignoreip,
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -23,8 +23,16 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease":[ "6", "7" ]
+    },
+    {
+      "operatingsystem": "DragonFly",
+      "operatingsystemrelease":[ "4.4-RELEASE" ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease":[ "9", "10" ]
     }
   ],
-  "tags": ["fail2ban", "iptables", "bruteforce", "firewall"]
+  "tags": ["fail2ban", "iptables", "bruteforce", "firewall", "pf"]
 }
 

--- a/templates/freebsd_jail.conf.erb
+++ b/templates/freebsd_jail.conf.erb
@@ -1,0 +1,209 @@
+#
+# WARNING: heavily refactored in 0.9.0 release.  Please review and
+#          customize settings for your setup.
+#
+# Changes:  in most of the cases you should not modify this
+#           file, but provide customizations in jail.local file,
+#           or separate .conf files under jail.d/ directory, e.g.:
+#
+# HOW TO ACTIVATE JAILS:
+#
+# YOU SHOULD NOT MODIFY THIS FILE.
+#
+# It will probably be overwritten or improved in a distribution update.
+#
+# Provide customizations in a jail.local file or a jail.d/customisation.local.
+# For example to change the default bantime for all jails and to enable the
+# ssh-iptables jail the following (uncommented) would appear in the .local file.
+# See man 5 jail.conf for details.
+#
+# [DEFAULT]
+# bantime = 3600
+#
+# [sshd]
+# enabled = true
+#
+# See jail.conf(5) man page for more information
+
+
+
+# Comments: use '#' for comment lines and ';' (following a space) for inline comments
+
+
+[INCLUDES]
+
+#before = paths-distro.conf
+before = paths-freebsd.conf
+
+# The DEFAULT allows a global definition of the options. They can be overridden
+# in each jail afterwards.
+
+[DEFAULT]
+
+#
+# MISCELLANEOUS OPTIONS
+#
+
+# "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban will not
+# ban a host which matches an address in this list. Several addresses can be
+# defined using space (and/or comma) separator.
+ignoreip = <%= @ignoreip %>
+
+# External command that will take an tagged arguments to ignore, e.g. <ip>,
+# and return true if the IP is to be ignored. False otherwise.
+#
+# ignorecommand = /path/to/command <ip>
+ignorecommand =
+
+# "bantime" is the number of seconds that a host is banned.
+bantime  = <%= @bantime %>
+
+# A host is banned if it has generated "maxretry" during the last "findtime"
+# seconds.
+findtime  = <%= @findtime %>
+
+# "maxretry" is the number of failures before a host get banned.
+maxretry = <%= @maxretry %>
+
+# "backend" specifies the backend used to get files modification.
+# Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
+# This option can be overridden in each jail as well.
+#
+# pyinotify: requires pyinotify (a file alteration monitor) to be installed.
+#              If pyinotify is not installed, Fail2ban will use auto.
+# gamin:     requires Gamin (a file alteration monitor) to be installed.
+#              If Gamin is not installed, Fail2ban will use auto.
+# polling:   uses a polling algorithm which does not require external libraries.
+# systemd:   uses systemd python library to access the systemd journal.
+#              Specifying "logpath" is not valid for this backend.
+#              See "journalmatch" in the jails associated filter config
+# auto:      will try to use the following backends, in order:
+#              pyinotify, gamin, polling.
+#
+# Note: if systemd backend is chosen as the default but you enable a jail
+#       for which logs are present only in its own log files, specify some other
+#       backend for that jail (e.g. polling) and provide empty value for
+#       journalmatch. See https://github.com/fail2ban/fail2ban/issues/959#issuecomment-74901200
+backend = <%= @backend %>
+
+# "usedns" specifies if jails should trust hostnames in logs,
+#   warn when DNS lookups are performed, or ignore all hostnames in logs
+#
+# yes:   if a hostname is encountered, a DNS lookup will be performed.
+# warn:  if a hostname is encountered, a DNS lookup will be performed,
+#        but it will be logged as a warning.
+# no:    if a hostname is encountered, will not be used for banning,
+#        but it will be logged as info.
+usedns = warn
+
+# "logencoding" specifies the encoding of the log files handled by the jail
+#   This is used to decode the lines from the log file.
+#   Typical examples:  "ascii", "utf-8"
+#
+#   auto:   will use the system locale setting
+logencoding = auto
+
+# "enabled" enables the jails.
+#  By default all jails are disabled, and it should stay this way.
+#  Enable only relevant to your setup jails in your .local or jail.d/*.conf
+#
+# true:  jail will be enabled and log files will get monitored for changes
+# false: jail is not enabled
+enabled = false
+
+
+# "filter" defines the filter to use by the jail.
+#  By default jails have names matching their filter name
+#
+filter = %(__name__)s
+
+
+#
+# ACTIONS
+#
+
+# Some options used for actions
+
+# Destination email address used solely for the interpolations in
+# jail.{conf,local,d/*} configuration files.
+destemail = <%= @destemail %>
+
+# Sender email address used solely for some actions
+sender = root@localhost
+
+# E-mail action. Since 0.8.1 Fail2Ban uses sendmail MTA for the
+# mailing. Change mta configuration parameter to mail if you want to
+# revert to conventional 'mail'.
+mta = <%= @mta %>
+
+# Default protocol
+protocol = <%= @protocol %>
+
+# Ports to be banned
+# Usually should be overridden in a particular jail
+port = 0:65535
+
+# Format of user-agent https://tools.ietf.org/html/rfc7231#section-5.5.3
+fail2ban_agent = Fail2Ban/%(fail2ban_version)s
+
+#
+# Action shortcuts. To be used to define action parameter
+
+# Default banning action (e.g. iptables, iptables-new,
+# iptables-multiport, shorewall, etc) It is used to define
+# action_* variables. Can be overridden globally or per
+# section within jail.local file
+banaction = iptables-multiport
+banaction_allports = iptables-allports
+
+# The simplest action to take: ban only
+action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with whois report to the destemail.
+action_mw = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+            %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_mwl = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# See the IMPORTANT note in action.d/xarf-login-attack for when to use this action
+#
+# ban & send a xarf e-mail to abuse contact of IP address and include relevant log lines
+# to the destemail.
+action_xarf = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath=%(logpath)s, port="%(port)s"]
+
+# ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]
+                %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# Report block via blocklist.de fail2ban reporting service API
+#
+# See the IMPORTANT note in action.d/blocklist_de.conf for when to
+# use this action. Create a file jail.d/blocklist_de.local containing
+# [Init]
+# blocklist_de_apikey = {api key from registration]
+#
+action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
+
+# Report ban via badips.com, and use as blacklist
+#
+# See BadIPsAction docstring in config/action.d/badips.py for
+# documentation for this action.
+#
+# NOTE: This action relies on banaction being present on start and therefore
+# should be last action defined for a jail.
+#
+action_badips = badips.py[category="%(__name__)s", banaction="%(banaction)s", agent="%(fail2ban_agent)s"]
+#
+# Report ban via badips.com (uses action.d/badips.conf for reporting only)
+#
+action_badips_report = badips[category="%(__name__)s", agent="%(fail2ban_agent)s"]
+
+# Choose default action.  To change, just override value of 'action' with the
+# interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
+# globally (section [DEFAULT]) or per specific section
+action = <%= @action %>

--- a/templates/pf.conf.erb
+++ b/templates/pf.conf.erb
@@ -1,0 +1,61 @@
+# Fail2Ban configuration file
+#
+# OpenBSD pf ban/unban
+#
+# Author: Nick Hilliard <nick@foobar.org>
+#
+#
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+# we don't enable PF automatically, as it will be enabled elsewhere
+actionstart =
+
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+# we don't disable PF automatically either
+actionstop =
+
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck =
+
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+actionban = <%= @pf_path -%>/pfctl -t <tablename> -T add <ip>/32
+
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    <ip>  IP address
+#          <failures>  number of failures
+#          <time>  unix timestamp of the ban time
+# Values:  CMD
+#
+# note -r option used to remove matching rule
+actionunban = <%= @pf_path -%>/pfctl -t <tablename> -T delete <ip>/32
+
+[Init]
+# Option:  tablename
+# Notes.:  The pf table name.
+# Values:  [ STRING ]
+#
+tablename = fail2ban


### PR DESCRIPTION
* Current concat from Puppetlabs changed data validation to allow integers in
  users and groups, so that has been cleaned up and the comment removed.

* Support for pf has been added for DragonFly and FreeBSD, though IPFW could
  still be added.

* README updated to include mention of new ssh support and OS support

* metadata updated to mention new OS support