### PR TITLE
Persistant ban function and usedns parameter for reverse dns lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,13 @@ global default values. These values can be overridden by individual jails.
  * `purge_jail_dot_d` Boolean value that decides whether
    `/etc/fail2ban/jail.d/` is purged of files that are not managed by puppet.
    Default value is true.
- * `usedns` specifies if jails should trust hostnames in logs. Options are 
+ * `usedns` Specifies if jails should trust hostnames in logs. Options are 
    yes, warn or no. Default is warn.
  * `persistant_ban` Boolean value that ensure bans persist over time.
-   `/etc/fail2ban/persistant.ban` file is create and populated by 
+   `/etc/fail2ban/persistant.ban` file is created and populated by 
    `/etc/fail2ban/action.d/iptables-multiport.conf`.
    Default value is false.
+
 ## Defining jails ##
 
 To define a jail, you can use one of the predefined jails (see list below). Or

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ global default values. These values can be overridden by individual jails.
  * `usedns` Specifies if jails should trust hostnames in logs. Options are 
    yes, warn or no. Default is warn.
  * `persistant_bans` Boolean value that ensure bans persist over time (0.8.x or older).
-   Feature is builtin with 0.9.x.
+   This feature is builtin with 0.9.x.
    `/etc/fail2ban/persistant.bans` file is created and populated by 
    `/etc/fail2ban/action.d/iptables-multiport.conf`.
    Default value is false.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ global default values. These values can be overridden by individual jails.
    `/etc/fail2ban/jail.d/` is purged of files that are not managed by puppet.
    Default value is true.
  * `usedns` specifies if jails should trust hostnames in logs. Options are 
-   yes, warn or no. 
-   Default is warn.
+   yes, warn or no. Default is warn.
  * `persistant_ban` Boolean value that ensure bans persist over time.
    `/etc/fail2ban/persistant.ban` file is create and populated by 
    `/etc/fail2ban/action.d/iptables-multiport.conf`.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ global default values. These values can be overridden by individual jails.
  * `purge_jail_dot_d` Boolean value that decides whether
    `/etc/fail2ban/jail.d/` is purged of files that are not managed by puppet.
    Default value is true.
-
+ * `usedns` specifies if jails should trust hostnames in logs. Options are 
+   yes, warn or no. 
+   Default is warn.
+ * `persistant_ban` Boolean value that ensure bans persist over time.
+   `/etc/fail2ban/persistant.ban` file is create and populated by 
+   `/etc/fail2ban/action.d/iptables-multiport.conf`.
+   Default value is false.
 ## Defining jails ##
 
 To define a jail, you can use one of the predefined jails (see list below). Or

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ global default values. These values can be overridden by individual jails.
    Default value is true.
  * `usedns` Specifies if jails should trust hostnames in logs. Options are 
    yes, warn or no. Default is warn.
- * `persistant_ban` Boolean value that ensure bans persist over time.
-   `/etc/fail2ban/persistant.ban` file is created and populated by 
+ * `persistant_bans` Boolean value that ensure bans persist over time (0.8.x or older).
+   Feature is builtin with 0.9.x.
+   `/etc/fail2ban/persistant.bans` file is created and populated by 
    `/etc/fail2ban/action.d/iptables-multiport.conf`.
    Default value is false.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,8 +17,7 @@ class fail2ban::config {
   $action          = $fail2ban::action
   $persistent_bans = $fail2ban::persistent_bans
   
-  $ips = split($ignoreip, " ")
-  validate_ip_address($ips)
+  validate_ip_address($ignoreip)
   validate_integer($bantime, $findtime, $maxretry)
   validate_bool($persistent_bans)
   validate_re($usedns, [ 'yes', 'no', 'warn' ], 'usedns value must be yes, no or warn.')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,8 +17,6 @@ class fail2ban::config {
   $action          = $fail2ban::action
   $persistent_bans = $fail2ban::persistent_bans
 
-  $ips = split($ignoreip, ' ')
-  validate_ip_address(join($ips, ", "))
   validate_integer($bantime, $findtime, $maxretry)
   validate_bool($persistent_bans)
   validate_re($usedns, [ 'yes', 'no', 'warn' ], 'usedns value must be yes, no or warn.')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,9 +17,7 @@ class fail2ban::config {
   $action          = $fail2ban::action
   $persistent_bans = $fail2ban::persistent_bans
   
-  # need to take absolute value in case bantime is a negative number.
-  $bantime_validate = abs($bantime)
-  validate_integer($bantime_validate)
+  validate_integer($bantime)
   validate_integer($findtime)
   validate_integer($maxretry)
   validate_bool($persistent_bans)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,7 +17,7 @@ class fail2ban::config {
   $action          = $fail2ban::action
   $persistent_bans = $fail2ban::persistent_bans
   
-  $ips = $ignoreip.split(" ")
+  $ips = split($ignoreip, " ")
   validate_ip_address($ips)
   validate_integer($bantime, $findtime, $maxretry)
   validate_bool($persistent_bans)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,18 +4,24 @@
 # to it.
 class fail2ban::config {
 
-  $ignoreip = $fail2ban::ignoreip
-  $bantime = $fail2ban::bantime
-  $findtime = $fail2ban::findtime
-  $maxretry = $fail2ban::maxretry
-  $backend = $fail2ban::backend
-  $usedns = $fail2ban::usedns
-  $destemail = $fail2ban::destemail
-  $banaction = $fail2ban::banaction
-  $mta = $fail2ban::mta
-  $protocol = $fail2ban::protocol
-  $action = $fail2ban::action
+  $ignoreip        = $fail2ban::ignoreip
+  $bantime         = $fail2ban::bantime
+  $findtime        = $fail2ban::findtime
+  $maxretry        = $fail2ban::maxretry
+  $backend         = $fail2ban::backend
+  $usedns          = $fail2ban::usedns
+  $destemail       = $fail2ban::destemail
+  $banaction       = $fail2ban::banaction
+  $mta             = $fail2ban::mta
+  $protocol        = $fail2ban::protocol
+  $action          = $fail2ban::action
   $persistent_bans = $fail2ban::persistent_bans
+  
+  $ips = $ignoreip.split(" ")
+  validate_ip_address($ips)
+  validate_integer($bantime, $findtime, $maxretry)
+  validate_bool($persistent_bans)
+  validate_re($usedns, [ 'yes', 'no', 'warn' ], 'usedns value must be yes, no or warn.')
 
   $jail_template_name = $::osfamily ? {
     'Debian' => "${module_name}/debian_jail.conf.erb",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,7 @@ class fail2ban::config {
   $persistent_bans = $fail2ban::persistent_bans
 
   $ips = split($ignoreip, ' ')
-  validate_ip_address(join($ips, ","))
+  validate_ip_address(join($ips, ", "))
   validate_integer($bantime, $findtime, $maxretry)
   validate_bool($persistent_bans)
   validate_re($usedns, [ 'yes', 'no', 'warn' ], 'usedns value must be yes, no or warn.')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,6 +14,7 @@ class fail2ban::config {
   $mta = $fail2ban::mta
   $protocol = $fail2ban::protocol
   $action = $fail2ban::action
+  $persistent_bans = $fail2ban::persistent_bans
 
   $jail_template_name = $::osfamily ? {
     'Debian' => "${module_name}/debian_jail.conf.erb",
@@ -77,4 +78,18 @@ class fail2ban::config {
     }
   }
 
+  if $persistent_bans {
+    file { '/etc/fail2ban/persistent.bans':
+      ensure  => 'present',
+      replace => 'no',
+      mode    => '0644',
+    }
+    file { '/etc/fail2ban/action.d/iptables-multiport.conf':
+      ensure  => present,
+      owner   => 'root',
+      group   => 0,
+      mode    => '0644',
+      content => template('fail2ban/iptables-multiport.erb'),
+    }
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,6 +29,12 @@ class fail2ban::config {
     default  => fail("Unsupported Operating System family: ${::osfamily}"),
   }
 
+  $before_include = $::osfamily ? {
+    'Debian' => "iptables-blocktype.conf",
+    'RedHat' => "iptables-common.conf",
+    default  => fail("Unsupported Operating System family: ${::osfamily}"),
+  }
+
   if $fail2ban::purge_jail_dot_d {
     if $::operatingsystem == 'Debian' and $::operatingsystemmajrelease == 7 {
       debug('Not purging jail.d on wheezy since the package doesn\'t include capability to use it.')
@@ -86,11 +92,6 @@ class fail2ban::config {
   }
 
   if $persistent_bans {
-    $before_include = $::osfamily ? {
-      'Debian' => "iptables-blocktype.conf",
-      'RedHat' => "iptables-common.conf",
-      default  => fail("Unsupported Operating System family: ${::osfamily}"),
-    }
     file { '/etc/fail2ban/persistent.bans':
       ensure  => 'present',
       replace => 'no',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,7 +20,6 @@ class fail2ban::config {
   $jail_template_name = $::osfamily ? {
     'Debian' => "${module_name}/debian_jail.conf.erb",
     'RedHat' => "${module_name}/rhel_jail.conf.erb",
-    'CentOS' => 
     default  => fail("Unsupported Operating System family: ${::osfamily}"),
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,7 @@ class fail2ban::config {
   $findtime = $fail2ban::findtime
   $maxretry = $fail2ban::maxretry
   $backend = $fail2ban::backend
+  $usedns = $fail2ban::usedns
   $destemail = $fail2ban::destemail
   $banaction = $fail2ban::banaction
   $mta = $fail2ban::mta
@@ -19,6 +20,7 @@ class fail2ban::config {
   $jail_template_name = $::osfamily ? {
     'Debian' => "${module_name}/debian_jail.conf.erb",
     'RedHat' => "${module_name}/rhel_jail.conf.erb",
+    'CentOS' => 
     default  => fail("Unsupported Operating System family: ${::osfamily}"),
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -86,6 +86,11 @@ class fail2ban::config {
   }
 
   if $persistent_bans {
+    $before_include = $::osfamily ? {
+      'Debian' => "iptables-blocktype.conf",
+      'RedHat' => "iptables-common.conf",
+      default  => fail("Unsupported Operating System family: ${::osfamily}"),
+    }
     file { '/etc/fail2ban/persistent.bans':
       ensure  => 'present',
       replace => 'no',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,8 +16,10 @@ class fail2ban::config {
   $protocol        = $fail2ban::protocol
   $action          = $fail2ban::action
   $persistent_bans = $fail2ban::persistent_bans
-
-  validate_integer($bantime, $findtime, $maxretry)
+  
+  # need to take absolute value in case bantime is a negative number.
+  $bantime_validate = abs($bantime)
+  validate_integer($bantime_validate, $findtime, $maxretry)
   validate_bool($persistent_bans)
   validate_re($usedns, [ 'yes', 'no', 'warn' ], 'usedns value must be yes, no or warn.')
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,9 @@ class fail2ban::config {
   
   # need to take absolute value in case bantime is a negative number.
   $bantime_validate = abs($bantime)
-  validate_integer($bantime_validate, $findtime, $maxretry)
+  validate_integer($bantime_validate)
+  validate_integer($findtime)
+  validate_integer($maxretry)
   validate_bool($persistent_bans)
   validate_re($usedns, [ 'yes', 'no', 'warn' ], 'usedns value must be yes, no or warn.')
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,8 +16,9 @@ class fail2ban::config {
   $protocol        = $fail2ban::protocol
   $action          = $fail2ban::action
   $persistent_bans = $fail2ban::persistent_bans
-  
-  validate_ip_address($ignoreip)
+
+  $ips = split($ignoreip, ' ')
+  validate_ip_address(join($ips, ","))
   validate_integer($bantime, $findtime, $maxretry)
   validate_bool($persistent_bans)
   validate_re($usedns, [ 'yes', 'no', 'warn' ], 'usedns value must be yes, no or warn.')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class fail2ban (
   $findtime         = '600',
   $maxretry         = '3',
   $backend          = 'auto',
+  $usedns           = 'warn',
   $destemail        = 'root@localhost',
   $banaction        = 'iptables-multiport',
   $mta              = 'sendmail',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,8 +14,8 @@ class fail2ban (
   $mta              = 'sendmail',
   $protocol         = 'tcp',
   $action           = '%(action_)s',
-  $purge_jail_dot_d = true
-  $persistent_bans  = false
+  $purge_jail_dot_d = true,
+  $persistent_bans  = false,
 ) {
 
   anchor { 'fail2ban::begin': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class fail2ban (
   $protocol         = 'tcp',
   $action           = '%(action_)s',
   $purge_jail_dot_d = true
+  $persistent_bans  = false
 ) {
 
   anchor { 'fail2ban::begin': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class fail2ban (
   $protocol         = 'tcp',
   $action           = '%(action_)s',
   $purge_jail_dot_d = true,
-  $persistent_bans  = false
+  $persistent_bans  = false,
 ) {
 
   anchor { 'fail2ban::begin': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class fail2ban (
   $protocol         = 'tcp',
   $action           = '%(action_)s',
   $purge_jail_dot_d = true,
-  $persistent_bans  = false,
+  $persistent_bans  = false
 ) {
 
   anchor { 'fail2ban::begin': } ->

--- a/templates/iptables-multiport.erb
+++ b/templates/iptables-multiport.erb
@@ -6,7 +6,7 @@
 
 [INCLUDES]
 
-before = iptables-blocktype.conf
+before = iptables-common.conf
 
 [Definition]
 

--- a/templates/iptables-multiport.erb
+++ b/templates/iptables-multiport.erb
@@ -6,7 +6,7 @@
 
 [INCLUDES]
 
-before = iptables-common.conf
+before = <%= @before_include %>
 
 [Definition]
 

--- a/templates/iptables-multiport.erb
+++ b/templates/iptables-multiport.erb
@@ -1,0 +1,54 @@
+# Fail2Ban configuration file
+#
+# Author: Cyril Jaquier
+# Modified by Yaroslav Halchenko for multiport banning
+#
+
+[INCLUDES]
+
+before = iptables-common.conf
+
+[Definition]
+
+# Option:  actionstart
+# Notes.:  command executed once at the start of Fail2Ban.
+# Values:  CMD
+#
+actionstart = <iptables> -N f2b-<name>
+              <iptables> -A f2b-<name> -j <returntype>
+              <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
+<% if @persistent_bans != false -%>          cat /etc/fail2ban/persistent.bans | awk '/^fail2ban-<name>/ {print $2}' \
+          | while read IP; do iptables -I fail2ban-<name> 1 -s $IP -j <blocktype>; done<% end -%>
+
+# Option:  actionstop
+# Notes.:  command executed once at the end of Fail2Ban
+# Values:  CMD
+#
+actionstop = <iptables> -D <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
+             <iptables> -F f2b-<name>
+             <iptables> -X f2b-<name>
+
+# Option:  actioncheck
+# Notes.:  command executed once before each actionban command
+# Values:  CMD
+#
+actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
+
+# Option:  actionban
+# Notes.:  command executed when banning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
+<% if @persistent_bans != false -%>        echo "fail2ban-<name> <ip>" >> /etc/fail2ban/persistent.bans<% end -%>
+
+# Option:  actionunban
+# Notes.:  command executed when unbanning an IP. Take care that the
+#          command is executed with Fail2Ban user rights.
+# Tags:    See jail.conf(5) man page
+# Values:  CMD
+#
+actionunban = <iptables> -D f2b-<name> -s <ip> -j <blocktype>
+
+[Init]

--- a/templates/iptables-multiport.erb
+++ b/templates/iptables-multiport.erb
@@ -42,7 +42,8 @@ actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 # Values:  CMD
 #
 actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
-<% if @persistent_bans != false -%>            echo "fail2ban-<name> <ip>" >> /etc/fail2ban/persistent.bans\n
+<% if @persistent_bans != false -%>            echo "fail2ban-<name> <ip>" >> /etc/fail2ban/persistent.bans
+
 <% end -%>
 
 # Option:  actionunban

--- a/templates/iptables-multiport.erb
+++ b/templates/iptables-multiport.erb
@@ -6,7 +6,7 @@
 
 [INCLUDES]
 
-before = iptables-common.conf
+before = iptables-blocktype.conf
 
 [Definition]
 
@@ -17,8 +17,8 @@ before = iptables-common.conf
 actionstart = <iptables> -N f2b-<name>
               <iptables> -A f2b-<name> -j <returntype>
               <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
-<% if @persistent_bans != false -%>              cat /etc/fail2ban/persistent.bans | awk '/^fail2ban-<name>/ {print $2}' \
-              | while read IP; do iptables -I fail2ban-<name> 1 -s $IP -j <blocktype>; done\n
+<% if @persistent_bans != false -%>              cat /etc/fail2ban/persistent.bans | awk '/^f2b-<name>/ {print $2}' \
+              | while read IP; do <iptables> -I f2b-<name> 1 -s $IP -j <blocktype>; done\n
 <% end -%>
 
 # Option:  actionstop
@@ -42,7 +42,7 @@ actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 # Values:  CMD
 #
 actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
-<% if @persistent_bans != false -%>            echo "fail2ban-<name> <ip>" >> /etc/fail2ban/persistent.bans
+<% if @persistent_bans != false -%>            echo "f2b-<name> <ip>" >> /etc/fail2ban/persistent.bans
 
 <% end -%>
 

--- a/templates/iptables-multiport.erb
+++ b/templates/iptables-multiport.erb
@@ -17,8 +17,9 @@ before = iptables-common.conf
 actionstart = <iptables> -N f2b-<name>
               <iptables> -A f2b-<name> -j <returntype>
               <iptables> -I <chain> -p <protocol> -m multiport --dports <port> -j f2b-<name>
-<% if @persistent_bans != false -%>          cat /etc/fail2ban/persistent.bans | awk '/^fail2ban-<name>/ {print $2}' \
-          | while read IP; do iptables -I fail2ban-<name> 1 -s $IP -j <blocktype>; done<% end -%>
+<% if @persistent_bans != false -%>              cat /etc/fail2ban/persistent.bans | awk '/^fail2ban-<name>/ {print $2}' \
+              | while read IP; do iptables -I fail2ban-<name> 1 -s $IP -j <blocktype>; done\n
+<% end -%>
 
 # Option:  actionstop
 # Notes.:  command executed once at the end of Fail2Ban
@@ -41,7 +42,8 @@ actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ \t]'
 # Values:  CMD
 #
 actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
-<% if @persistent_bans != false -%>        echo "fail2ban-<name> <ip>" >> /etc/fail2ban/persistent.bans<% end -%>
+<% if @persistent_bans != false -%>            echo "fail2ban-<name> <ip>" >> /etc/fail2ban/persistent.bans\n
+<% end -%>
 
 # Option:  actionunban
 # Notes.:  command executed when unbanning an IP. Take care that the

--- a/templates/rhel_jail.conf.erb
+++ b/templates/rhel_jail.conf.erb
@@ -68,7 +68,7 @@ backend = <%= @backend %>
 #        but it will be logged as a warning.
 # no:    if a hostname is encountered, will not be used for banning,
 #        but it will be logged as info.
-usedns = warn
+usedns = <%= @usedns %>
 
 # "logencoding" specifies the encoding of the log files handled by the jail
 #   This is used to decode the lines from the log file.


### PR DESCRIPTION
Added the ability to set usedns to (yes, warn or no) and drop a template in for iptables-multiport.conf that adds 3 lines that allow you hold a persistent ban list. It appears this is the way most folks have been doing this. 

RE: https://arno0x0x.wordpress.com/2015/12/30/fail2ban-permanent-persistent-bans/

It would be great if you merged this in. If you have any idea about better ways please feel free to let me know. 
Thanks,
Lui