### PR TITLE
Add systemd compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Here's the full list of parameters you can use:
  * `port` List of port names, separated by commas, that will get blocked for a
    banned IP. Can be "all" to block all ports. This parameter is mandatory.
  * `filter` Name of the filter to use. This parameter is mandatory.
- * `logpath` Path of the log to monitor. This parameter is mandatory.
+ * `logpath` Path of the log to monitor. This parameter is mandatory unless
+   you are using the systemd backend in which case it should not be set.
  * `ensure` Set this to `absent` to remove a jail. This parameter is useless
    with the default value of `purge_jail_dot_d` since removing the jail
    resource will remove the jail file. It can be useful if you set

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,9 +21,18 @@ class fail2ban (
 ) {
 
   validate_array($ignoreip)
+  $valid_backends = [
+      'auto',
+      'pyinotify',
+      'gamin',
+      'polling',
+      'systemd'
+  ]
+  $valid_backend_message = join($valid_backends, ', ')
+
   validate_re(
-    $backend, ['auto', 'pyinotify', 'gamin', 'polling'],
-    'backend must be one of auto, pyinotify, gamin or polling.'
+    $backend, $valid_backends,
+    "backend must be one of: ${valid_backend_message}."
   )
   validate_re(
     $protocol, ['tcp', 'udp', 'icmp', 'all'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,10 +36,10 @@ class fail2ban (
   )
   validate_bool($persistent_bans)
 
-  anchor { 'fail2ban::begin': } ->
-  class { 'fail2ban::install': } ->
-  class { 'fail2ban::config': } ~>
-  class { 'fail2ban::service': } ->
-  anchor { 'fail2ban::end': }
+  anchor { 'fail2ban::begin': }
+  -> class { 'fail2ban::install': }
+  -> class { 'fail2ban::config': }
+  ~> class { 'fail2ban::service': }
+  -> anchor { 'fail2ban::end': }
 
 }

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -3,7 +3,7 @@
 define fail2ban::jail (
   $port,
   $filter,
-  $logpath,
+  $logpath   = false,
   $ensure    = present,
   $enabled   = true,
   $protocol  = false,
@@ -25,6 +25,7 @@ define fail2ban::jail (
   if $maxretry { validate_integer($maxretry, '', 0) }
   if $findtime { validate_integer($findtime, '', 0) }
   if $bantime { validate_integer($bantime, '', 0) }
+  if $backend != 'systemd' and $logpath == false { fail 'logpath must be set unless $backend is \'systemd\'' }
   validate_array($ignoreip)
 
   if $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') < 1 {

--- a/templates/jail.erb
+++ b/templates/jail.erb
@@ -2,7 +2,8 @@
 enabled = <%= @enabled %>
 port = <%= @port %>
 filter = <%= @filter %>
-logpath = <%= @logpath %>
+<% if @logpath != false -%>logpath = <%= @logpath %>
+<% end -%>
 <% if @protocol != false -%>protocol = <%= @protocol %>
 <% end -%>
 <% if @maxretry != false -%>maxretry = <%= @maxretry %>


### PR DESCRIPTION
Hey Lelutin,

This is for https://github.com/lelutin/puppet-fail2ban/issues/22

This PR makes logpath optional so that this module can be used with the systemd backend as fail2ban expressly states that logpath should not be set when using the systemd backend.

I have tested this and it works but please let me know if you would like me to amend anything.

Thanks,

Alan