### PR TITLE
Add missing notifies

### DIFF
--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -56,6 +56,7 @@ define fail2ban::jail (
       owner   => 'root',
       group   => 0,
       mode    => '0644',
+      notify  => Class['fail2ban::service']
     }
   }
 


### PR DESCRIPTION
Hey Lelutin,

During my testing I found that jails were not loaded in fail2ban after the puppet code had finished running.

I then attempted a reload and sure enough they were then defined.

In my code I manually added notifies into the jail blocks to ensure that puppet was restarted and they were loaded however really this should be dealt with in the module.

This PR adds notifies to various blocks to ensure that fail2ban is reloaded to pick up any changes made by the module.

Please let me know if anything needs to be amended.

Thanks,

Alan Jenkins