### PR TITLE
Convert 'all' to 1:65535 for iptables.

### DIFF
--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -60,6 +60,15 @@ define fail2ban::jail (
     if $order {
       warning('The parameter order can presently only be used with Debian wheezy. It is planned to be removed when wheezy is no longer supported')
     }
+
+    if $port == 'all' {
+      $portrange = '1:65535'
+    }
+    else
+    {
+      $portrange = $port
+    }
+
     file { "/etc/fail2ban/jail.d/${name}.conf":
       ensure  => $ensure,
       content => template('fail2ban/jail.erb'),

--- a/templates/jail.erb
+++ b/templates/jail.erb
@@ -1,6 +1,6 @@
 [<%= @name %>]
 enabled = <%= @enabled %>
-port = <%= @port %>
+port = <%= @portrange %>
 filter = <%= @filter %>
 <% if @logpath != false -%>logpath = <%= @logpath %>
 <% end -%>


### PR DESCRIPTION
Hey Lelutin,

This is one way to handle the 'all' port specification. Can you think of a better way to handle it?

Thanks,

Alan Jenkins