### PR TITLE
Add ignorecommand

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,6 +8,7 @@ class fail2ban::config {
   $bantime = $fail2ban::bantime
   $findtime = $fail2ban::findtime
   $maxretry = $fail2ban::maxretry
+  $ignorecommand = $fail2ban::ignorecommand
   $backend = $fail2ban::backend
   $destemail = $fail2ban::destemail
   $banaction = $fail2ban::banaction

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class fail2ban (
   $bantime          = '600',
   $findtime         = '600',
   $maxretry         = '3',
+  $ignorecommand    = '',
   $backend          = 'auto',
   $destemail        = 'root@localhost',
   $banaction        = 'iptables-multiport',

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -9,6 +9,7 @@ define fail2ban::jail (
   $protocol  = false,
   $maxretry  = false,
   $findtime  = false,
+  $ignorecommand = undef,
   $action    = false,
   $banaction = false,
   $bantime   = false,

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -9,7 +9,7 @@ define fail2ban::jail (
   $protocol  = false,
   $maxretry  = false,
   $findtime  = false,
-  $ignorecommand = undef,
+  $ignorecommand = false,
   $action    = false,
   $banaction = false,
   $bantime   = false,

--- a/templates/debian_jail.conf.erb
+++ b/templates/debian_jail.conf.erb
@@ -22,6 +22,12 @@ ignoreip = <%= @ignoreip.join(" ") %>
 bantime = <%= @bantime %>
 maxretry = <%= @maxretry %>
 
+# External command that will take an tagged arguments to ignore, e.g. <ip>,
+# and return true if the IP is to be ignored. False otherwise.
+#
+# ignorecommand = /path/to/command <ip>
+ignorecommand =  <%= @ignorecommand %>
+  
 # A host is banned if it has generated "maxretry" during the last "findtime"
 # seconds.
 findtime  = <%= @findtime %>

--- a/templates/jail.erb
+++ b/templates/jail.erb
@@ -12,6 +12,8 @@ filter = <%= @filter %>
 <% end -%>
 <% if @action != false -%>action = <%= @action %>
 <% end -%>
+<% if @ignorecommand != false -%>ignorecommand = <%= @ignorecommand %>
+<% end -%>
 <% if @banaction != false -%>banaction = <%= @banaction %>
 <% end -%>
 <% if @bantime != false -%>bantime = <%= @bantime %>

--- a/templates/rhel_jail.conf.erb
+++ b/templates/rhel_jail.conf.erb
@@ -28,7 +28,7 @@ ignoreip = <%= @ignoreip.join(" ") %>
 # and return true if the IP is to be ignored. False otherwise.
 #
 # ignorecommand = /path/to/command <ip>
-ignorecommand =
+ignorecommand = <%= @ignorecommand %>
 
 # "bantime" is the number of seconds that a host is banned.
 bantime = <%= @bantime %>


### PR DESCRIPTION
Allow the use of the "ignorecommand" option both globally and as part of individual jail configuration. Most specifically this is required for the apache-fakegooglebot config to work properly.

I didn't put any validation on the input from the puppet conf on those commands. The docs say it should follow the pattern of ``/path/to/command <ip>`` so I don't know if we want to put in a regex or some kind, validate that the command path exists or anything like that.

Figure start the discussion.