### PR TITLE
Remove puppet 4.x warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class fail2ban (
   $persistent_bans  = false,
 ) {
 
-  validate_array($ignoreip)
+  validate_legacy('Stdlib::Compat::Array', 'validate_array', $ignoreip)
   $valid_backends = [
       'auto',
       'pyinotify',
@@ -33,20 +33,20 @@ class fail2ban (
   ]
   $valid_backend_message = join($valid_backends, ', ')
 
-  validate_re(
+  validate_legacy('Pattern', 'validate_re',
     $backend, $valid_backends,
     "backend must be one of: ${valid_backend_message}."
   )
-  validate_re(
+  validate_legacy('Pattern', 'validate_re',
     $protocol, ['tcp', 'udp', 'icmp', 'all'],
     'protocol must be one of tcp, udp, icmp or all.'
   )
-  validate_bool($rm_jail_local)
-  validate_bool($purge_jail_dot_d)
-  validate_re(
+  validate_legacy('Stdlib::Compat::Bool', 'validate_bool', $rm_jail_local)
+  validate_legacy('Stdlib::Compat::Bool', 'validate_bool', $purge_jail_dot_d)
+  validate_legacy('Pattern', 'validate_re',
     $usedns, ['yes', 'no', 'warn'], 'usedns value must be yes, no or warn.'
   )
-  validate_bool($persistent_bans)
+  validate_legacy('Stdlib::Compat::Bool', 'validate_bool', $persistent_bans)
 
   anchor { 'fail2ban::begin': }
   -> class { 'fail2ban::install': }

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -18,13 +18,14 @@ define fail2ban::jail (
 ) {
   include fail2ban::config
 
-  validate_re(
+  validate_legacy('Pattern', 'validate_re',
     $ensure, ['present', 'absent'], 'ensure must be either present or absent.'
   )
-  validate_bool($enabled)
-  if $maxretry { validate_integer($maxretry, '', 0) }
-  if $findtime { validate_integer($findtime, '', 0) }
-  if $bantime { validate_integer($bantime, '', 0) }
+  validate_legacy('Stdlib::Compat::Bool', 'validate_bool', $enabled)
+
+  if $maxretry { validate_legacy('Stdlib::Compat::Integer', 'validate_integer', $maxretry, '', 0) }
+  if $findtime { validate_legacy('Stdlib::Compat::Integer', 'validate_integer', $findtime, '', 0) }
+  if $bantime { validate_legacy('Stdlib::Compat::Integer', 'validate_integer', $bantime, '', 0) }
   if $backend == 'systemd' {
     if $logpath {
       fail('logpath must not be set when $backend is \'systemd\'')
@@ -35,7 +36,7 @@ define fail2ban::jail (
       fail('logpath must be set unless $backend is \'systemd\'')
     }
   }
-  validate_array($ignoreip)
+  validate_legacy('Stdlib::Compat::Array', 'validate_array', $ignoreip)
 
   if $port == 'all' {
     $portrange = '1:65535'

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/lelutin/puppet-fail2ban",
   "issues_url": "https://github.com/lelutin/puppet-fail2ban/issues",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.0.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This change removes warning emitted by stdlib when  puppet 4.x is used.

It uses validate_legacy() method to keep puppet 3.x compat.

Closes #26