### PR TITLE
Added before_include variable to RedHat section of fail2ban::config.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,10 @@ class fail2ban::config {
       $jail_template_name = "${module_name}/debian/jail.conf.erb"
       $before_include = 'iptables-common.conf'
     }
-    'RedHat': { $jail_template_name = "${module_name}/rhel/jail.conf.erb" }
+    'RedHat': {
+      $jail_template_name = "${module_name}/rhel/jail.conf.erb"
+      $before_include = 'iptables-common.conf'
+    }
     default: { fail("Unsupported Operating System family: ${::osfamily}") }
   }
 


### PR DESCRIPTION
I found with using the latest version of your module that numerous iptables errors were being produced.  For example:

`fail2ban.action         [4063965]: ERROR   <iptables> -N f2b-ssh`
`<iptables> -A f2b-ssh -j <returntype>`
`<iptables> -I INPUT -p tcp -m multiport --dports ssh -j f2b-ssh -- stderr: "/bin/sh: iptables: No such file or directory\n/bin/sh: -c: line 1: syntax error near unexpected token `newline'\n/bin/sh: -c: line 1: `<iptables>  A f2b-ssh -j <returntype>'\n"`

As you can see there is a new line after `fail2ban.action         [4063965]: ERROR   <iptables> -N f2b-ssh` (I got a similar error for every jail I set up with the module).  I was able to fix this by using the same variable that is in the Debian section of fail2ban::config in the RedHat section.