### PR TITLE
hiera updated to version 5

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,10 +1,8 @@
 ---
-version: 4
-datadir: data
+version: 5
 hierarchy:
   - name: "OS family"
-    backend: yaml
-    path: "%{facts.os.family}"
+    path: "%{facts.os.family}.yaml"
 
   - name: "common"
-    backend: yaml
+    path: "common.yaml"

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,6 @@
       "operatingsystemrelease":[ "6", "7" ]
     }
   ],
-  "data_provider": "hiera",
   "tags": ["fail2ban", "iptables", "bruteforce", "firewall"]
 }
 


### PR DESCRIPTION
This change is introduced to suppress deprecation warnings in Puppet 6.x