### PR TITLE
Raising dependency on stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/lelutin/puppet-fail2ban",
   "issues_url": "https://github.com/lelutin/puppet-fail2ban/issues",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 7.0.0"}
   ],
   "requirements": [
     {


### PR DESCRIPTION
This PR raises the depdency on Forge module stdlib to be < 7.0.0.  Version 6.0.0 of stdlib was released in May, 2019 and doesn't appear to have any breaking changes.