### PR TITLE
make the service management optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,8 @@
 # @param ignoreregex
 #   Regular expressions to add to all filters' ignoreregex. This is usually not
 #   used but could be useful to have something excluded from bans everywhere.
+# @param manage_service
+#   Manage the fail2ban service, true by default
 #
 class fail2ban (
   # Options that change how the module behaves
@@ -167,6 +169,7 @@ class fail2ban (
   String             $logencoding        = 'auto',
   Optional[String]   $failregex          = undef,
   Optional[String]   $ignoreregex        = undef,
+  Boolean            $manage_service     = true,
 ) inherits fail2ban::params {
 
   if $persistent_bans {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,10 +9,12 @@
 #
 class fail2ban::service {
 
-  service { 'fail2ban':
-    ensure    => running,
-    enable    => true,
-    hasstatus => true,
+  if $fail2ban::manage_service {
+    service { 'fail2ban':
+      ensure    => running,
+      enable    => true,
+      hasstatus => true,
+    }
   }
 
 }


### PR DESCRIPTION
Hello

thanks for the module, it is very useful :) 

however in my case I stop fail2ban in my pre firewall class  and start it again in my post firewall class, but the module gets in the middle and starts fail2ban before its time.

this PR makes the service management optional, keeping the default as true

