### PR TITLE
draft: reduce diff with debian bullseye

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -77,6 +77,7 @@ class fail2ban::config {
   $persistent_bans = $fail2ban::persistent_bans
 
   $enabled = $fail2ban::enabled
+  $mode = $fail2ban::mode
   $filter = $fail2ban::filter
   $ignoreip = $fail2ban::ignoreip
   $bantime = $fail2ban::bantime

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,7 +148,8 @@ class fail2ban (
   String[1]                      $jail_conf_template
     = $fail2ban::params::jail_conf_template,
   Boolean                        $enabled            = false,
-  String                         $filter             = '%(__name__)s',
+  String                         $mode               = 'normal',
+  String                         $filter             = '%(__name__)s[mode=%(mode)s]',
   Array[String, 0]               $ignoreip           = ['127.0.0.1'],
   Integer                        $bantime            = 600,
   Integer                        $findtime           = 600,

--- a/templates/debian/jail.conf.erb
+++ b/templates/debian/jail.conf.erb
@@ -116,6 +116,8 @@ logpath = <%= [@logpath].flatten().join("\n          ") %>
 # false: jail is not enabled
 enabled = <%= @enabled %>
 
+# "mode" defines the mode of the filter (see corresponding filter implementation for more info).
+mode = <%= @mode %>
 
 # "filter" defines the filter to use by the jail.
 #  By default jails have names matching their filter name

--- a/templates/fail2ban.conf.erb
+++ b/templates/fail2ban.conf.erb
@@ -30,7 +30,7 @@ loglevel = <%= @loglvl %>
 #         using logrotate -- also adjust or disable rotation in the
 #         corresponding configuration file
 #         (e.g. /etc/logrotate.d/fail2ban on Debian systems)
-# Values: [ STDOUT | STDERR | SYSLOG | FILE ]  Default: STDERR
+# Values: [ STDOUT | STDERR | SYSLOG | SYSOUT | FILE ]  Default: STDERR
 #
 logtarget = <%= @logtarget %>
 


### PR DESCRIPTION
This does not *completely* remove it, obviously some things remain,
like:

 * all the sample jails
 * times like "1d" (which we only allow integers for)
 * whitespace changes

There may also be other changes I forgot, I lost the actual
before/after diff, sorry.

This is also untested.