### PR TITLE
Fix stdlib deprectations

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,5 +8,5 @@
 # @api private
 #
 class fail2ban::install {
-  ensure_packages(['fail2ban'])
+  stdlib::ensure_packages(['fail2ban'])
 }

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -264,7 +264,7 @@ define fail2ban::jail (
 
   $jail_template_values = {
     jail_name => $name,
-    options   => merge($additional_options, $jail_options),
+    options   => stdlib::merge($additional_options, $jail_options),
   }
   file { "/etc/fail2ban/jail.d/${name}.conf":
     ensure  => $ensure,


### PR DESCRIPTION
This fixes `stdlib` deprecations after allowing version 9 in #75.

Here's what I was getting:
```
Warning: This function is deprecated, please use stdlib::ensure_packages instead. at ["/etc/puppetlabs/code/modules/fail2ban/manifests/install.pp", 11]:["/etc/puppetlabs/code/modules/fail2ban/manifests/init.pp", 265]
   (location: /etc/puppetlabs/code/modules/stdlib/lib/puppet/functions/deprecation.rb:35:in `deprecation')
Warning: This function is deprecated, please use stdlib::merge instead. at ["/etc/puppetlabs/code/modules/fail2ban/manifests/jail.pp", 267]:
   (location: /etc/puppetlabs/code/modules/stdlib/lib/puppet/functions/deprecation.rb:35:in `deprecation')
```